### PR TITLE
fix: custom styling with toastOptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,7 +233,7 @@ You can style your toasts globally with the `toastOptions` prop in the `Toaster`
 
 ```html
 <Toaster
-  toastOptions="{
+  :toastOptions="{
     style: { background: 'red' },
     className: 'my-toast',
     descriptionClassName: 'my-toast-description'

--- a/packages/Toast.vue
+++ b/packages/Toast.vue
@@ -31,7 +31,7 @@
       '--z-index': toasts.length - props.index,
       '--offset': `${removed ? offsetBeforeRemove : offset}px`,
       '--initial-height': props.expandByDefault ? 'auto' : `${initialHeight}px`,
-      ...toast
+      ...toastStyle
     }"
     @pointerdown="onPointerDown"
     @pointerup="onPointerUp"
@@ -211,6 +211,7 @@ const isVisible = computed(() => props.index + 1 <= props.visibleToasts)
 const toastType = computed(() => props.toast.type)
 const toastClass = props.toast.className || ''
 const toastDescriptionClass = props.toast.descriptionClassName || ''
+const toastStyle = props.toast.style || {}
 
 // Height index is used to calculate the offset as it gets updated before the toast array, which means we can calculate the new layout faster.
 const heightIndex = computed(


### PR DESCRIPTION
Hello @xiaoluoboding 
Just appreciate this package with fine style.

Refer to issue #9 
The docs should be fixed to this:
```html
<Toaster
  :toastOptions="{     //  vue v-bind object
    style: { background: 'red' },
    className: 'my-toast',
    descriptionClassName: 'my-toast-description'
  }"
/>
```

And for styling for individual toast demonstrated in docs:
```ts
toast('Event has been created', {
  style: {
    background: 'red'
  },
  className: 'my-toast',
  descriptionClassName: 'my-toast-description'
})
```

The styling was wrapped in a style object, so unwrapped it should fix the issue.

