### PR TITLE
fix: custom component memory leaks

### DIFF
--- a/components.d.ts
+++ b/components.d.ts
@@ -10,7 +10,6 @@ declare module '@vue/runtime-core' {
     'Carbon:cafe': typeof import('~icons/carbon/cafe')['default']
     'Carbon:logoTwitter': typeof import('~icons/carbon/logo-twitter')['default']
     CheckIcon: typeof import('./src/components/icons/CheckIcon.vue')['default']
-    copy: typeof import('./src/components/Expand copy.vue')['default']
     CopyIcon: typeof import('./src/components/icons/CopyIcon.vue')['default']
     Expand: typeof import('./src/components/Expand.vue')['default']
     Footer: typeof import('./src/components/Footer.vue')['default']

--- a/packages/Toast.vue
+++ b/packages/Toast.vue
@@ -67,7 +67,17 @@
           {{ promiseTitle }}
         </template>
         <template v-else-if="isTitleComponent">
-          <component :is="toast.title" />
+          <component
+            :is="toast.title"
+            @close="
+              () => {
+                deleteToast()
+                if (toast.cancel?.onClick) {
+                  toast.cancel.onClick()
+                }
+              }
+            "
+          />
         </template>
       </div>
       <template v-if="toast.description">

--- a/packages/Toast.vue
+++ b/packages/Toast.vue
@@ -69,7 +69,7 @@
         <template v-else-if="isTitleComponent">
           <component
             :is="toast.title"
-            @close="
+            @closeToast="
               () => {
                 deleteToast()
                 if (toast.cancel?.onClick) {

--- a/src/components/HeadlessToast.vue
+++ b/src/components/HeadlessToast.vue
@@ -2,7 +2,7 @@
   <div class="headless">
     <p class="headlessTitle">Event Created</p>
     <p class="headlessDescription">Today at 4:00pm - "Louvre Museum"</p>
-    <button class="headlessClose" @click="$emit('close')">
+    <button class="headlessClose" @click="$emit('closeToast')">
       <svg width="14" height="14" viewBox="0 0 16 16" fill="currentColor">
         <path
           d="M2.96967 2.96967C3.26256 2.67678 3.73744 2.67678 4.03033 2.96967L8 6.939L11.9697 2.96967C12.2626 2.67678 12.7374 2.67678 13.0303 2.96967C13.3232 3.26256 13.3232 3.73744 13.0303 4.03033L9.061 8L13.0303 11.9697C13.2966 12.2359 13.3208 12.6526 13.1029 12.9462L13.0303 13.0303C12.7374 13.3232 12.2626 13.3232 11.9697 13.0303L8 9.061L4.03033 13.0303C3.73744 13.3232 3.26256 13.3232 2.96967 13.0303C2.67678 12.7374 2.67678 12.2626 2.96967 11.9697L6.939 8L2.96967 4.03033C2.7034 3.76406 2.6792 3.3474 2.89705 3.05379L2.96967 2.96967Z"

--- a/src/components/HeadlessToast.vue
+++ b/src/components/HeadlessToast.vue
@@ -2,7 +2,7 @@
   <div class="headless">
     <p class="headlessTitle">Event Created</p>
     <p class="headlessDescription">Today at 4:00pm - "Louvre Museum"</p>
-    <button class="headlessClose" @click="() => toast.dismiss(t)">
+    <button class="headlessClose" @click="$emit('close')">
       <svg width="14" height="14" viewBox="0 0 16 16" fill="currentColor">
         <path
           d="M2.96967 2.96967C3.26256 2.67678 3.73744 2.67678 4.03033 2.96967L8 6.939L11.9697 2.96967C12.2626 2.67678 12.7374 2.67678 13.0303 2.96967C13.3232 3.26256 13.3232 3.73744 13.0303 4.03033L9.061 8L13.0303 11.9697C13.2966 12.2359 13.3208 12.6526 13.1029 12.9462L13.0303 13.0303C12.7374 13.3232 12.2626 13.3232 11.9697 13.0303L8 9.061L4.03033 13.0303C3.73744 13.3232 3.26256 13.3232 2.96967 13.0303C2.67678 12.7374 2.67678 12.2626 2.96967 11.9697L6.939 8L2.96967 4.03033C2.7034 3.76406 2.6792 3.3474 2.89705 3.05379L2.96967 2.96967Z"
@@ -11,16 +11,6 @@
     </button>
   </div>
 </template>
-
-<script setup lang="ts">
-import type { PropType } from 'vue'
-
-import { toast } from '../../packages'
-
-defineProps({
-  t: [String, Number] as PropType<string | number>
-})
-</script>
 
 <style scoped>
 .headless {

--- a/src/components/Others.vue
+++ b/src/components/Others.vue
@@ -97,11 +97,11 @@ const allTypes = [
   },
   {
     name: 'Headless',
-    snippet: `import { shallowRef } from 'vue'
+    snippet: `import { markRaw } from 'vue'
 
 import HeadlessToast from './HeadlessToast.vue'
 
-toast.custom(shallowRef(HeadlessToast));
+toast.custom(markRaw(HeadlessToast));
 `,
     action: () => {
       toast.custom(markRaw(HeadlessToast), { duration: 999999 })

--- a/src/components/Others.vue
+++ b/src/components/Others.vue
@@ -41,7 +41,7 @@
 </template>
 
 <script lang="ts" setup>
-import { ref, shallowRef } from 'vue'
+import { markRaw, ref } from 'vue'
 
 import { toast } from '../../packages'
 import HeadlessToast from './HeadlessToast.vue'
@@ -104,7 +104,7 @@ import HeadlessToast from './HeadlessToast.vue'
 toast.custom(shallowRef(HeadlessToast));
 `,
     action: () => {
-      toast.custom(shallowRef(HeadlessToast), { duration: 999999 })
+      toast.custom(markRaw(HeadlessToast), { duration: 999999 })
       emit('setCloseButton')
     }
   }

--- a/src/components/Types.vue
+++ b/src/components/Types.vue
@@ -45,7 +45,7 @@
 </template>
 
 <script lang="ts" setup>
-import { ref, h, defineComponent, shallowRef } from 'vue'
+import { ref, h, defineComponent, markRaw } from 'vue'
 import { toast } from '../../packages'
 import { useCopyCode } from '~/composables/useCopyCode'
 import CopyIcon from '~/components/icons/CopyIcon.vue'
@@ -147,7 +147,7 @@ const CustomDiv = defineComponent({
 
 toast(shallowRef(CustomDiv))
 `,
-    action: () => toast(shallowRef(CustomDiv))
+    action: () => toast(markRaw(CustomDiv))
   }
 ]
 

--- a/src/components/Types.vue
+++ b/src/components/Types.vue
@@ -134,7 +134,7 @@ toast.promise(promise, {
   },
   {
     name: 'Custom',
-    snippet: `import { defineComponent, h, shallowRef } from 'vue'
+    snippet: `import { defineComponent, h, markRaw } from 'vue'
 
 const CustomDiv = defineComponent({
   setup() {
@@ -145,7 +145,7 @@ const CustomDiv = defineComponent({
   }
 })
 
-toast(shallowRef(CustomDiv))
+toast(markRaw(CustomDiv))
 `,
     action: () => toast(markRaw(CustomDiv))
   }


### PR DESCRIPTION
This PR fixes custom component usage by:

- using `markRaw` instead of `shallowRef` so that the component will never be converted to a proxy
- emitting close event from the custom component, then the `Toast` component receives and calls the `deleteToast` function.

Fixes
- https://github.com/xiaoluoboding/vue-sonner/issues/18
- https://github.com/xiaoluoboding/vue-sonner/issues/15

Any custom component then can just do `$emit('closeToast')` and the toast should close. Here's an example:

```js
import { defineComponent, h, markRaw } from 'vue'
import { toast } from 'vue-sonner'

const Custom = defineComponent({
  setup(_props, { emit }) {
    return () =>
      h('button', {
        onClick: () => emit('closeToast')
      }, 'Click me to close')
  }
})

toast(markRaw(Custom))
```