### PR TITLE
Replace function props with component events

### DIFF
--- a/components.d.ts
+++ b/components.d.ts
@@ -10,7 +10,6 @@ declare module '@vue/runtime-core' {
     'Carbon:cafe': typeof import('~icons/carbon/cafe')['default']
     'Carbon:logoTwitter': typeof import('~icons/carbon/logo-twitter')['default']
     CheckIcon: typeof import('./src/components/icons/CheckIcon.vue')['default']
-    copy: typeof import('./src/components/Expand copy.vue')['default']
     CopyIcon: typeof import('./src/components/icons/CopyIcon.vue')['default']
     Expand: typeof import('./src/components/Expand.vue')['default']
     Footer: typeof import('./src/components/Footer.vue')['default']

--- a/packages/Toast.vue
+++ b/packages/Toast.vue
@@ -136,6 +136,7 @@ const isPromise = (toast: ToastT): toast is PromiseData & { id: number } =>
 
 const emit = defineEmits<{
   (e: 'update:heights', heights: HeightT[]): void
+  (e: 'removeToast', toast: ToastT): void
 }>()
 
 const props = defineProps({
@@ -161,10 +162,6 @@ const props = defineProps({
   },
   heights: {
     type: Array as PropType<HeightT[]>,
-    required: true
-  },
-  removeToast: {
-    type: Function as PropType<(toast: ToastT) => void>,
     required: true
   },
   position: {
@@ -330,7 +327,7 @@ function deleteToast() {
   emit('update:heights', newHeights)
 
   setTimeout(() => {
-    props.removeToast(props.toast)
+    emit('removeToast', props.toast)
   }, TIME_BEFORE_UNMOUNT)
 }
 

--- a/packages/Toast.vue
+++ b/packages/Toast.vue
@@ -134,6 +134,10 @@ const TIME_BEFORE_UNMOUNT = 200
 const isPromise = (toast: ToastT): toast is PromiseData & { id: number } =>
   Boolean(toast.promise)
 
+const emit = defineEmits<{
+  (e: 'update:heights', heights: HeightT[]): void
+}>()
+
 const props = defineProps({
   toast: {
     type: Object as PropType<ToastT>,
@@ -157,10 +161,6 @@ const props = defineProps({
   },
   heights: {
     type: Array as PropType<HeightT[]>,
-    required: true
-  },
-  setHeights: {
-    type: Function,
     required: true
   },
   removeToast: {
@@ -326,10 +326,8 @@ function deleteToast() {
   // Save the offset for the exit swipe animation
   removed.value = true
   offsetBeforeRemove.value = offset.value
-  // emit('update:heights', props.heights.filter((height) => height.toastId !== props.toast.id))
-  props.setHeights(
-    props.heights.filter((height) => height.toastId !== props.toast.id)
-  )
+  const newHeights = props.heights.filter((height) => height.toastId !== props.toast.id)
+  emit('update:heights', newHeights)
 
   setTimeout(() => {
     props.removeToast(props.toast)
@@ -430,17 +428,16 @@ onMounted(() => {
     const height = toastRef.value.getBoundingClientRect().height
     // Add toast height tot heights array after the toast is mounted
     initialHeight.value = height
-    // emit('update:heights', [{ toastId: props.toast.id, height }, ...props.heights])
-    props.setHeights([{ toastId: props.toast.id, height }, ...props.heights])
+
+    const newHeights = [{ toastId: props.toast.id, height }, ...props.heights]
+    emit('update:heights', newHeights)
   }
 })
 
 onUnmounted(() => {
   if (toastRef.value) {
-    // emit('update:heights', props.heights.filter((height) => height.toastId !== props.toast.id))
-    props.setHeights(
-      props.heights.filter((height) => height.toastId !== props.toast.id)
-    )
+    const newHeights = props.heights.filter((height) => height.toastId !== props.toast.id)
+    emit('update:heights', newHeights)
   }
 })
 

--- a/packages/Toaster.vue
+++ b/packages/Toaster.vue
@@ -46,10 +46,9 @@
           :style="toastOptions?.style"
           :removeToast="removeToast"
           :toasts="toasts"
-          :heights="heights"
-          :setHeights="setHeights"
           :expandByDefault="expand"
           :expanded="expanded"
+          v-model:heights="heights"
         />
       </template>
     </ol>

--- a/packages/Toaster.vue
+++ b/packages/Toaster.vue
@@ -44,11 +44,11 @@
           :interacting="interacting"
           :position="position"
           :style="toastOptions?.style"
-          :removeToast="removeToast"
           :toasts="toasts"
           :expandByDefault="expand"
           :expanded="expanded"
           v-model:heights="heights"
+          @removeToast="removeToast"
         />
       </template>
     </ol>
@@ -138,10 +138,6 @@ const hotkeyLabel = props.hotkey
   .join('+')
   .replace(/Key/g, '')
   .replace(/Digit/g, '')
-
-function setHeights(heightsPayload: HeightT[]) {
-  heights.value = heightsPayload
-}
 
 function removeToast(toast: ToastT) {
   toasts.value = toasts.value.filter(({ id }) => id !== toast.id)


### PR DESCRIPTION
This PR updates `removeToast` and `setHeights` function props to be emitted events instead.

We love to follow Vue's philosophy - props down, events up.