### PR TITLE
fix: ignore type definitions

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
   "exports": {
     ".": {
       "import": "./lib/vue-sonner.js",
-      "require": "./lib/vue-sonner.umd.cjs"
+      "require": "./lib/vue-sonner.umd.cjs",
+      "types": "./lib/index.d.ts"
     }
   },
   "sideEffects": [


### PR DESCRIPTION
This PR is about typescript error `Could not find a declaration file`.

<img width="704" alt="" src="https://github.com/xiaoluoboding/vue-sonner/assets/78361904/cea8d54f-8e23-4040-9905-76da742604f6">

---
After looking into this, I found some related issues:
[vuex#2213](https://github.com/vuejs/vuex/issues/2213#issue-1595847351) 
[vuex#2223](https://github.com/vuejs/vuex/issues/2223#issue-1703566525)

It seems like typescript would ignore types definitions in `package.json` depends on `nodeResolution`.
So I try to manually modify `node_ modules` like [vuex#2223](https://github.com/vuejs/vuex/issues/2223#issue-1703566525) and it works fine.

Let me know any updates, thank you.

env:
```
"vue": "^3.3.4",
"vue-sonner": "^0.3.3",
"vite": "^4.3.9",
"typescript": "~5.0.4",
"vue-tsc": "^1.6.5"
```