### PR TITLE
fix: remove default offset

### DIFF
--- a/components.d.ts
+++ b/components.d.ts
@@ -7,6 +7,8 @@ export {}
 
 declare module '@vue/runtime-core' {
   export interface GlobalComponents {
+    'Carbon:cafe': typeof import('~icons/carbon/cafe')['default']
+    'Carbon:logoTwitter': typeof import('~icons/carbon/logo-twitter')['default']
     CheckIcon: typeof import('./src/components/icons/CheckIcon.vue')['default']
     CopyIcon: typeof import('./src/components/icons/CopyIcon.vue')['default']
     Expand: typeof import('./src/components/Expand.vue')['default']
@@ -14,6 +16,7 @@ declare module '@vue/runtime-core' {
     HeadlessToast: typeof import('./src/components/HeadlessToast.vue')['default']
     Hero: typeof import('./src/components/Hero.vue')['default']
     Installation: typeof import('./src/components/Installation.vue')['default']
+    'Mdi:heart': typeof import('~icons/mdi/heart')['default']
     Others: typeof import('./src/components/Others.vue')['default']
     Position: typeof import('./src/components/Position.vue')['default']
     Styling: typeof import('./src/components/Styling.vue')['default']

--- a/packages/Toaster.vue
+++ b/packages/Toaster.vue
@@ -114,7 +114,6 @@ const props = withDefaults(defineProps<ToasterProps>(), {
   hotkey: () => ['altKey', 'KeyT'],
   richColors: false,
   expand: false,
-  duration: Number,
   visibleToasts: VISIBLE_TOASTS_AMOUNT,
   closeButton: false,
   toastOptions: () => ({}),

--- a/packages/Toaster.vue
+++ b/packages/Toaster.vue
@@ -118,7 +118,6 @@ const props = withDefaults(defineProps<ToasterProps>(), {
   visibleToasts: 3,
   closeButton: false,
   toastOptions: () => ({}),
-  offset: 0
 })
 
 const attrs = useAttrs()

--- a/packages/Toaster.vue
+++ b/packages/Toaster.vue
@@ -115,7 +115,7 @@ const props = withDefaults(defineProps<ToasterProps>(), {
   richColors: false,
   expand: false,
   duration: Number,
-  visibleToasts: 3,
+  visibleToasts: VISIBLE_TOASTS_AMOUNT,
   closeButton: false,
   toastOptions: () => ({}),
 })


### PR DESCRIPTION
Default offset is 32px using the `VIEWPORT_OFFSET` variable:

<img width="761" alt="Screenshot 2023-08-05 at 10 46 09 PM" src="https://github.com/xiaoluoboding/vue-sonner/assets/13049130/0b83da0a-66f4-4a0e-a6f9-ebe18d4c6a1a">

It was never used, since vue-sonner v0.4.0 has a `0` initial value for the `offset` prop:

<img width="495" alt="Screenshot 2023-08-05 at 10 47 37 PM" src="https://github.com/xiaoluoboding/vue-sonner/assets/13049130/a06e0631-fdff-4b15-afb2-424626296940">

If you look at the demo website, there is no offset between the browser and the toast component:

<img width="433" alt="Screenshot 2023-08-05 at 10 45 14 PM" src="https://github.com/xiaoluoboding/vue-sonner/assets/13049130/ba0ee18b-b4a5-4eec-aa27-46cdfa98ecf6">

This PR removes the default offset and fixes some types.