### PR TITLE
feat: add extraProps to be passed to toast

### DIFF
--- a/packages/Toast.vue
+++ b/packages/Toast.vue
@@ -1,5 +1,6 @@
 <template>
   <li
+    v-bind="props.toast.extraProps"
     :aria-live="toast.important ? 'assertive' : 'polite'"
     aria-atomic
     role="status"
@@ -333,7 +334,9 @@ function deleteToast() {
   // Save the offset for the exit swipe animation
   removed.value = true
   offsetBeforeRemove.value = offset.value
-  const newHeights = props.heights.filter((height) => height.toastId !== props.toast.id)
+  const newHeights = props.heights.filter(
+    (height) => height.toastId !== props.toast.id
+  )
   emit('update:heights', newHeights)
 
   setTimeout(() => {
@@ -443,7 +446,9 @@ onMounted(() => {
 
 onUnmounted(() => {
   if (toastRef.value) {
-    const newHeights = props.heights.filter((height) => height.toastId !== props.toast.id)
+    const newHeights = props.heights.filter(
+      (height) => height.toastId !== props.toast.id
+    )
     emit('update:heights', newHeights)
   }
 })

--- a/packages/types.ts
+++ b/packages/types.ts
@@ -13,6 +13,7 @@ export type PromiseData = ExternalToast & {
 }
 
 export interface ToastT {
+  extraProps?: Record<string, any>
   id: number | string
   title?: string | Component
   type?: ToastTypes


### PR DESCRIPTION
Add the property in toast function and ToastT type.

All properties of extraProps will be passed to html, e.g. if extraProps contains 'data-testid': 'toast', the rendered html will have that property.