### PR TITLE
fix: blurry text in chromium

### DIFF
--- a/packages/styles.css
+++ b/packages/styles.css
@@ -164,6 +164,7 @@ html[dir='rtl'],
   display: flex;
   flex-direction: column;
   gap: 2px;
+  transform: translateZ(0);
 }
 
 [data-sonner-toast] [data-button] {


### PR DESCRIPTION
currently, the text in chromium-based browsers looks like this (viewport 1920x911):
![image](https://github.com/xiaoluoboding/vue-sonner/assets/26815728/e7aaba20-2193-496f-ac03-683491940f27)

this pr removes this blurriness and now the text is easy to read (viewport 1920x911):
![image](https://github.com/xiaoluoboding/vue-sonner/assets/26815728/311dc0ca-620e-4aa4-9a67-2a535ce00d79)

neither firefox nor safari have this problem, it's an [old bug](https://stackoverflow.com/questions/31109299/css-transform-translate-50-50-makes-texts-blurry) in chromium