### PR TITLE
fix(Toast): :bug: move the heights update to Toaster.vue

### DIFF
--- a/packages/Toast.vue
+++ b/packages/Toast.vue
@@ -269,10 +269,6 @@ const deleteToast = () => {
   // Save the offset for the exit swipe animation
   removed.value = true
   offsetBeforeRemove.value = offset.value
-  const newHeights = props.heights.filter(
-    (height) => height.toastId !== props.toast.id
-  )
-  emit('update:heights', newHeights)
 
   setTimeout(() => {
     emit('removeToast', props.toast)

--- a/packages/Toaster.vue
+++ b/packages/Toaster.vue
@@ -221,6 +221,7 @@ const hotkeyLabel = props.hotkey
   .replace(/Digit/g, '')
 
 function removeToast(toast: ToastT) {
+  heights.value = heights.value.filter(({ toastId }) => toastId !== toast.id)
   toasts.value = toasts.value.filter(({ id }) => id !== toast.id)
 }
 


### PR DESCRIPTION
It seems that when we programmatically perform a `dismiss()` we go into a loop in the `Toaster` component. Moving the height update from the `Toast` component to the `Toaster` solves the problem "_Maximum recursive updates exceeded in component_"

Closes https://github.com/xiaoluoboding/vue-sonner/issues/63