### PR TITLE
fix: add icon classes

### DIFF
--- a/src/packages/Toast.vue
+++ b/src/packages/Toast.vue
@@ -72,7 +72,7 @@
 
     <template v-else>
       <template v-if="toastType !== 'default' || toast.icon || toast.promise">
-        <div data-icon="">
+        <div data-icon="" :class="cn(classes?.icon, toast?.classes?.icon)">
           <template
             v-if="(toast.promise || toastType === 'loading') && !toast.icon"
           >


### PR DESCRIPTION
Hey, great library! 

I'm not sure if this is the solution you'd want to go for, but I noticed the `icon` classes were not being applied, despite being defined in `ToastClasses`:
https://github.com/xiaoluoboding/vue-sonner/blob/01435c8daef8809ceaf1f7cdc216fe7dbb6df0f1/src/packages/types.ts#L45

It's setup the same as with [the React version](https://github.com/emilkowalski/sonner/blob/55c42f850ebc5c59070367ea46bf0cb1b2c38fb6/src/index.tsx#L364).
