### PR TITLE
fix: use nuxt add component util for toaster

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -1,4 +1,9 @@
-import { defineNuxtModule, addPlugin, createResolver } from '@nuxt/kit'
+import {
+  defineNuxtModule,
+  addComponent,
+  addPlugin,
+  createResolver
+} from '@nuxt/kit'
 
 import type { NuxtModule } from '@nuxt/schema'
 
@@ -15,6 +20,12 @@ const module: NuxtModule<ModuleOptions> = defineNuxtModule<ModuleOptions>({
   defaults: {},
   setup(options: ModuleOptions, nuxt) {
     const { resolve } = createResolver(import.meta.url)
+
+    addComponent({
+      name: 'Toaster',
+      export: 'Toaster',
+      filePath: 'vue-sonner'
+    })
 
     addPlugin({
       src: resolve('./runtime/plugin'),

--- a/src/runtime/plugin.ts
+++ b/src/runtime/plugin.ts
@@ -1,11 +1,7 @@
-import { Toaster, toast } from 'vue-sonner'
+import { toast } from 'vue-sonner'
 import { defineNuxtPlugin } from 'nuxt/app'
 
-import type { NuxtApp } from 'nuxt/app'
-
-export default defineNuxtPlugin((nuxtApp: NuxtApp) => {
-  nuxtApp.vueApp.component('Toaster', Toaster)
-
+export default defineNuxtPlugin(() => {
   return {
     provide: {
       toast


### PR DESCRIPTION
This allows `<Toaster />` component types to be available, and the Toaster component will only be loaded if it is actually imported. Thanks!