### PR TITLE
fix: improve CSS insertion logic to handle document loading state

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -80,11 +80,21 @@ export default defineConfig(({ command, mode }) => {
             code: `\
             function __insertCSSVueSonner(code) {
               if (!code || typeof document == 'undefined') return
-              let head = document.head || document.getElementsByTagName('head')[0]
-              let style = document.createElement('style')
-              style.type = 'text/css'
-              head.appendChild(style)
-              ;style.styleSheet ? (style.styleSheet.cssText = code) : style.appendChild(document.createTextNode(code))
+              
+              function insertCSS() {
+                let head = document.head || document.getElementsByTagName('head')[0]
+                if (!head) return
+                let style = document.createElement('style')
+                style.type = 'text/css'
+                head.appendChild(style)
+                style.styleSheet ? (style.styleSheet.cssText = code) : style.appendChild(document.createTextNode(code))
+              }
+
+              if (document.readyState === 'loading') {
+                document.addEventListener('DOMContentLoaded', insertCSS)
+              } else {
+                insertCSS()
+              }
             }\n
             __insertCSSVueSonner(${JSON.stringify(cssCodeStr)})
             \n ${code}`,


### PR DESCRIPTION
I've updated the `__insertCSSVueSonner` function to handle cases where the DOM might not be immediately available. This addresses potential issues in environments like Chrome extensions where content scripts can run before DOM load.

This small change ensures safer CSS insertion across different scenarios without affecting existing functionality.