### PR TITLE
feat: add option to import css manually

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,11 @@
       "import": "./lib/vue-sonner.js",
       "require": "./lib/vue-sonner.cjs"
     },
+     "./manual": {
+      "types": "./lib/vue-sonner.d.ts",
+      "import": "./lib/vue-sonner.manual.js",
+      "require": "./lib/vue-sonner.manual.cjs"
+    },
     "./nuxt": {
       "import": {
         "types": "./lib/nuxt/types.d.mts",
@@ -44,7 +49,8 @@
         "types": "./lib/nuxt/types.d.ts",
         "default": "./lib/nuxt/module.cjs"
       }
-    }
+    },
+    "./style.css": "./lib/style.css"
   },
   "sideEffects": [
     "**/*.css"

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -35,25 +35,35 @@ export default defineConfig(({ command, mode }) => {
   if (mode === 'lib') {
     userConfig.build = {
       lib: {
-        entry: resolve(__dirname, 'src/packages/index.ts'),
-        name: 'VueSonner',
-        fileName: 'vue-sonner'
+        entry: {
+          'vue-sonner': resolve(__dirname, 'src/packages/index.ts'),
+          'manual-css': resolve(__dirname, 'src/packages/index.ts')
+        },
+        fileName: (format, entryName) => {
+          if (entryName === 'vue-sonner') {
+            return `vue-sonner.${format === 'es' ? 'js' : format}`
+          }
+          if (entryName === 'manual-css') {
+            return `vue-sonner.manual.${format === 'es' ? 'js' : format}`
+          }
+        },
+        formats: ['es', 'cjs']
       },
       outDir: 'lib',
       emptyOutDir: true,
-      cssCodeSplit: false,
+      cssCodeSplit: true,
       sourcemap: true,
       rollupOptions: {
         external: ['vue'],
         output: [
           {
             format: 'cjs',
-            entryFileNames: `vue-sonner.cjs`
+            assetFileNames: 'style.css'
           },
           {
             format: 'es',
-            entryFileNames: `vue-sonner.js`,
-            preserveModules: false
+            preserveModules: false,
+            assetFileNames: 'style.css'
           }
         ]
       }
@@ -62,42 +72,52 @@ export default defineConfig(({ command, mode }) => {
       ...commonPlugins,
       {
         name: 'inline-css',
+        buildStart() {
+          cssCodeStr = ''
+        },
         transform(code, id) {
           const isCSS = (path: string) => /\.css$/.test(path)
           if (!isCSS(id)) return
 
-          const cssCode = minify(code)
-          cssCodeStr = cssCode
+          const minifiedCss = minify(code)
+          cssCodeStr += minifiedCss
           return {
-            code: '',
+            code: minifiedCss,
             map: { mappings: '' }
           }
         },
-        renderChunk(code, { isEntry }) {
-          if (!isEntry) return
+        renderChunk(code, chunk) {
+          if (!chunk.isEntry) return null
 
+          if (chunk.name === 'vue-sonner') {
+            return {
+              code: `\
+              function __insertCSSVueSonner(code) {
+                if (!code || typeof document == 'undefined') return
+                
+                function insertCSS() {
+  
+                  let head = document.head || document.getElementsByTagName('head')[0]
+                  if (!head) return
+                  let style = document.createElement('style')
+                  style.type = 'text/css'
+                  head.appendChild(style)
+                  style.styleSheet ? (style.styleSheet.cssText = code) : style.appendChild(document.createTextNode(code))
+                }
+  
+                if (document.readyState === 'loading') {
+                  document.addEventListener('DOMContentLoaded', insertCSS)
+                } else {
+                  insertCSS()
+                }
+              }\n
+              __insertCSSVueSonner(${JSON.stringify(cssCodeStr)})
+              \n ${code}`,
+              map: { mappings: '' }
+            }
+          }
           return {
-            code: `\
-            function __insertCSSVueSonner(code) {
-              if (!code || typeof document == 'undefined') return
-              
-              function insertCSS() {
-                let head = document.head || document.getElementsByTagName('head')[0]
-                if (!head) return
-                let style = document.createElement('style')
-                style.type = 'text/css'
-                head.appendChild(style)
-                style.styleSheet ? (style.styleSheet.cssText = code) : style.appendChild(document.createTextNode(code))
-              }
-
-              if (document.readyState === 'loading') {
-                document.addEventListener('DOMContentLoaded', insertCSS)
-              } else {
-                insertCSS()
-              }
-            }\n
-            __insertCSSVueSonner(${JSON.stringify(cssCodeStr)})
-            \n ${code}`,
+            code,
             map: { mappings: '' }
           }
         }


### PR DESCRIPTION
I needed a way to use vue-sonner inside a web component and therefore insert the css manually. I've updated the vite config to add the style.css to the build output and added a separate entry point which doesn't include the __insertCSSVueSonner function.

If someone wants to use the library without the css auto insert they can import from 'vue-sonner/manual'.  import from 'vue-sonner' will still auto insert the css.

example
```html
<!-- App.vue -->
<script>
import { toast, Toaster } from 'vue-sonner/manual'
</script>

<style>
@import 'vue-sonner/style.css'
</style>
``` 

@xiaoluoboding let me know if that's something you want to support. If yes I can also update the docs.

- Close https://github.com/xiaoluoboding/vue-sonner/issues/104
- Close https://github.com/xiaoluoboding/vue-sonner/issues/108