### PR TITLE
fix: active toasts

### DIFF
--- a/src/packages/hooks.ts
+++ b/src/packages/hooks.ts
@@ -87,7 +87,8 @@ export function useVueSonner(): {
   watchEffect((onInvalidate) => {
     const unsubscribe = ToastState.subscribe((toast) => {
       if ('dismiss' in toast && toast.dismiss) {
-        return activeToasts.value.filter((t) => t.id !== toast.id)
+        activeToasts.value = activeToasts.value.filter((t) => t.id !== toast.id)
+        return
       }
 
       nextTick(() => {


### PR DESCRIPTION
This PR fixes the `activeToasts` in `useVueSonner`composable.

The bug is that the array keeps the dismissed toasts.