### PR TITLE
fix: postcss-calc will change the style

### DIFF
--- a/src/packages/Toaster.vue
+++ b/src/packages/Toaster.vue
@@ -705,7 +705,7 @@ html[dir='rtl'],
 
 [data-sonner-toast][data-expanded='false'][data-front='false'] {
   --scale: var(--toasts-before) * 0.05 + 1;
-  --y: translateY(calc(var(--lift-amount) * var(--toasts-before))) scale(calc(-1 * var(--scale)));
+  --y: translateY(calc(var(--lift-amount) * var(--toasts-before))) scale(calc(-1 * var(--toasts-before) * 0.05 + 1));
   height: var(--front-toast-height);
 }
 


### PR DESCRIPTION
postcss会导致css中的一段内容发生变化，导致效果出错

之前 --> postcss 之后
``` css
--scale: var(--toasts-before) * 0.05 + 1;

scale(calc( -1 * calc(--scale)));  --> scale(calc(  var(--toasts-before) * 0.05 + 1 * -1));
```
