### PR TITLE
📦 feat(umd): add UMD-compatible plugin entrypoint and tsdown build

### DIFF
--- a/globals.d.ts
+++ b/globals.d.ts
@@ -1,0 +1,26 @@
+// globals.d.ts
+
+// Import the type of the toast object from the toast state module
+import type { toast } from './src/packages/state'
+
+// Ensure this file is treated as a module
+export {}
+
+/**
+ * Global window interface augmentation
+ *
+ * Adds the `toast` object to the `window` global scope
+ * to enable usage of `window.toast` in non-Vue contexts
+ * such as plain JavaScript or legacy code.
+ *
+ * This is particularly useful in UMD builds where Composition API
+ * and dependency injection are not available.
+ */
+declare global {
+  interface Window {
+    /**
+     * Globally accessible toast object (e.g. window.toast.success('...'))
+     */
+    toast: typeof toast
+  }
+}

--- a/package.json
+++ b/package.json
@@ -27,8 +27,8 @@
       }
     },
     "./src/*": {
-      "default": "./src/*",
-      "import": "./src/*"
+      "import": "./src/*",
+      "default": "./src/*"
     }
   },
   "main": "./lib/index.js",

--- a/package.json
+++ b/package.json
@@ -49,7 +49,8 @@
     "build:docs": "vite build --mode docs",
     "build:lib": "tsdown",
     "build:module": "nuxt-module-build build --outDir lib/nuxt",
-    "release": "pnpm run build:lib && pnpm run build:module",
+    "build:umd:prod": "tsdown --config tsdown.config.umd.ts",
+    "release": "pnpm run build:lib && pnpm run build:module && pnpm run build:umd:prod",
     "preview": "vite preview",
     "test": "cd ./test && pnpm test:e2e --ui",
     "changelog": "conventional-changelog -p angular -i CHANGELOG.md -s -r 0"
@@ -61,6 +62,7 @@
     "@nuxt/module-builder": "^1.0.1",
     "@nuxt/schema": "^3.17.3",
     "@nuxt/test-utils": "^3.19.0",
+    "@senojs/rollup-plugin-style-inject": "^0.2.3",
     "@types/node": "^20.17.47",
     "@unocss/reset": "^66.1.2",
     "@vitejs/plugin-vue": "^5.2.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,6 +26,9 @@ importers:
       '@nuxt/test-utils':
         specifier: ^3.19.0
         version: 3.19.0(@playwright/test@1.52.0)(@types/node@20.17.50)(jiti@2.4.2)(magicast@0.3.5)(playwright-core@1.52.0)(terser@5.39.2)(typescript@5.8.3)(yaml@2.8.0)
+      '@senojs/rollup-plugin-style-inject':
+        specifier: ^0.2.3
+        version: 0.2.3
       '@types/node':
         specifier: ^20.17.47
         version: 20.17.50
@@ -1274,6 +1277,10 @@ packages:
     resolution: {integrity: sha512-h1J+Yzjo/X+0EAvR2kIXJDuTuyT7drc+t2ALY0nIcGPbTatNOf0VWdhEA2Z4AAjv6X1NJV7SYo5oCTYRJhSlVA==}
     cpu: [x64]
     os: [win32]
+
+  '@senojs/rollup-plugin-style-inject@0.2.3':
+    resolution: {integrity: sha512-3/spt7JG2iHMW1YdtFbDafWa4IYNkJ99tibY7oDe5LXVTq2JxBpOsdRmJyCCqI5I4kBoUUYWS2yEG/FKwrLy/A==}
+    engines: {node: '>=12'}
 
   '@sindresorhus/is@7.0.1':
     resolution: {integrity: sha512-QWLl2P+rsCJeofkDNIT3WFmb6NrRud1SUYW8dIhXK/46XFV8Q/g7Bsvib0Askb0reRLe+WYPeeE+l5cH7SlkuQ==}
@@ -6179,6 +6186,8 @@ snapshots:
 
   '@rollup/rollup-win32-x64-msvc@4.41.0':
     optional: true
+
+  '@senojs/rollup-plugin-style-inject@0.2.3': {}
 
   '@sindresorhus/is@7.0.1': {}
 

--- a/src/plugin.umd.ts
+++ b/src/plugin.umd.ts
@@ -1,0 +1,58 @@
+import { toast } from './packages/state'
+import Toaster from './packages/Toaster.vue'
+
+/**
+ * VueSonner plugin for Vue 3
+ * 
+ * - Globally registers the `<Toaster />` component
+ * - Adds `$toast` to all component instances (Options API)
+ * - Provides `toast` via Vue’s dependency injection (Composition API)
+ * - Automatically exposes `window.toast` in UMD builds for use in plain JS
+ *
+ * @example
+ * // index.html (UMD / CDN build)
+ * <script src="https://unpkg.com/vue@3"></script>
+ * <script src="https://unpkg.com/vue-sonner"></script>
+ * <script>
+ *   const app = Vue.createApp({})
+ *   app.use(VueSonner)
+ *   app.mount('#app')
+ *
+ *   // Toast usage anywhere (even outside Vue)
+ *   toast.success('This works globally!')
+ * </script>
+ *
+ * @example
+ * // Inside a Vue component (Options API)
+ * this.$toast.success('Message sent!')
+ *
+ * @example
+ * // Inside a Vue component (Composition API)
+ * import { inject } from 'vue'
+ * const toast = inject('toast')
+ * toast?.error('Something went wrong!')
+ */
+const VueSonner = {
+  /**
+   * Install function used by Vue.use()
+   * @param {App} app - The Vue application instance
+   */
+  install(app) {
+    // Make $toast globally available in Options API
+    app.config.globalProperties.$toast = toast
+
+    // Register the <Toaster /> component globally
+    app.component('Toaster', Toaster)
+
+    // Provide toast for Composition API usage
+    app.provide('toast', toast)
+
+      // assign toast to window
+    if (typeof window !== 'undefined') {
+      window.toast = toast
+    }
+  }
+}
+
+// UMD-friendly single export for Vue.use(VueSonner)
+export default VueSonner

--- a/tsdown.config.umd.ts
+++ b/tsdown.config.umd.ts
@@ -35,8 +35,7 @@ export default defineConfig({
 
     // Inject styles into <head> at runtime instead of emitting a .css file
     //
-    // 📝 I tried many modern plugins like:
-    // - rollup-plugin-style-inject
+    // 📝 We tried many modern plugins like:
     // - rollup-plugin-styles
     // - other Vue rollup integrations
     //

--- a/tsdown.config.umd.ts
+++ b/tsdown.config.umd.ts
@@ -48,11 +48,25 @@ export default defineConfig({
     styleInject({
       insertAt: 'top'
     }),
+
+    // Plugin to prevent empty CSS files from being generated
+    // Since we're using styleInject to inline styles, we don't want separate CSS files
+    {
+      name: 'no-empty-css-emit',
+      generateBundle(options, bundle) {
+        // Remove any CSS files from the bundle since styles are inlined
+        Object.keys(bundle).forEach((fileName) => {
+          if (fileName.endsWith('.css')) {
+            delete bundle[fileName]
+          }
+        })
+      }
+    }
   ],
 
   outputOptions: {
     // Bundle location and file name
-    dir: 'dist/umd',
+    dir: 'lib/umd',
     entryFileNames: 'vue-sonner.umd.prod.js',
 
     // Define globals for UMD build

--- a/tsdown.config.umd.ts
+++ b/tsdown.config.umd.ts
@@ -1,0 +1,64 @@
+import { defineConfig } from 'tsdown'
+import Vue from 'unplugin-vue/rolldown'
+import styleInject from '@senojs/rollup-plugin-style-inject'
+
+export default defineConfig({
+  // Entry point for the UMD build
+  entry: ['src/plugin.umd.ts'],
+
+  // Use specific tsconfig for build output
+  tsconfig: './tsconfig.build.json',
+
+  // Output as UMD format (for browser global usage)
+  format: ['umd'],
+
+  // Compile for browser runtime
+  platform: 'browser',
+
+  // Global variable name used in <script> tag
+  globalName: 'VueSonner',
+
+  // Use modern JavaScript
+  target: 'ESNext',
+
+  // Output options
+  sourcemap: false,
+  minify: true,
+  clean: true,
+
+  // Treat 'vue' as external (consumer must provide it)
+  external: ['vue'],
+
+  plugins: [
+    // Transforms Vue SFC files
+    Vue({ isProduction: true }),
+
+    // Inject styles into <head> at runtime instead of emitting a .css file
+    //
+    // 📝 I tried many modern plugins like:
+    // - rollup-plugin-style-inject
+    // - rollup-plugin-styles
+    // - other Vue rollup integrations
+    //
+    // None of them could:
+    // - inline CSS into the UMD .js file
+    // - avoid emitting a separate .css file
+    //
+    // ✅ This older plugin (`@senojs/rollup-plugin-style-inject`) still works perfectly.
+    // It inlines <style> tags into the final JS bundle, making distribution simple.
+    styleInject({
+      insertAt: 'top'
+    }),
+  ],
+
+  outputOptions: {
+    // Bundle location and file name
+    dir: 'dist/umd',
+    entryFileNames: 'vue-sonner.umd.prod.js',
+
+    // Define globals for UMD build
+    globals: {
+      vue: 'Vue'
+    }
+  }
+})


### PR DESCRIPTION
This PR adds robust UMD support to `vue-sonner`, allowing it to be used via `<script>` tags without bundlers or build tools. The new setup uses `tsdown` for output and inlines CSS directly into the UMD JavaScript file.

---

### 🔌 Plugin Improvements (`src/plugin.umd.ts`)

* ✅ Registers `<Toaster />` globally
* ✅ Injects `toast` via `app.provide()` (Composition API)
* ✅ Adds `$toast` to `app.config.globalProperties` (Options API)
* ✅ Exposes `window.toast` globally in UMD builds
* 🧪 Includes usage examples for both Vue and plain JS

---

### 🔧 UMD Build via `tsdown`

* ✅ Uses `tsdown.config.umd.ts` for cleaner build control
* ✅ Outputs a single `.js` file: `dist/vue-sonner.umd.prod.js`
* ✅ CSS is **inlined directly** into JS — no separate `.css` file
* ✅ `vue` is treated as external (`Vue` must be globally available)

---

### 🧩 Why I Used an Older Plugin

> After trying many modern plugins like:
>
> * `rollup-plugin-styles`
> * various Vue rollup integrations
>
> ❌ None of them could:
>
> * inline CSS into the UMD `.js` bundle
> * avoid emitting a separate `.css` file
>
> ✅ This older plugin — [`[@senojs/rollup-plugin-style-inject](https://www.npmjs.com/package/@senojs/rollup-plugin-style-inject)`](https://www.npmjs.com/package/@senojs/rollup-plugin-style-inject) — still works perfectly.
> It injects `<style>` tags at runtime into the document `<head>`, making the UMD bundle completely self-contained and ideal for CDN usage.

---

### 📦 Package Updates

* 🆕 Adds `build:umd:prod` using `tsdown`
* 🔁 Updates `release` script to include UMD build
* 📄 Adds `globals.d.ts` to declare `window.toast`

---

### ✅ Why It Matters

* 🌍 Enables **CDN-based usage** (UMD + `<script>` tag)
* 🧠 Works in **legacy** or **non-module** environments
* 🎯 Aligns with the `tsdown` build philosophy
* 🧼 Produces a **single distributable file** (JS with inlined styles)
* 🛠 Simplifies integration — no bundler, no CSS imports, no fuss
