### PR TITLE
fix: custom component not trigger on dismiss function

### DIFF
--- a/src/packages/state.ts
+++ b/src/packages/state.ts
@@ -299,7 +299,27 @@ class Observer {
   // We can't provide the toast we just created as a prop as we didn't create it yet, so we can create a default toast object, I just don't know how to use function in argument when calling()?
   custom = (component: Component, data?: ExternalToast) => {
     const id = data?.id || toastsCounter++
-    this.publish({ component, id, ...data })
+    const alreadyExists = this.toasts.find((toast) => {
+      return toast.id === id
+    })
+    const dismissible = data?.dismissible === undefined ? true : data.dismissible
+
+    if (this.dismissedToasts.has(id)) {
+      this.dismissedToasts.delete(id)
+    }
+
+    if (alreadyExists) {
+      this.toasts = this.toasts.map((toast) => {
+        if (toast.id === id) {
+          this.publish({ ...toast, component, dismissible, id, ...data })
+          return { ...toast, component, dismissible, id, ...data, }
+        }
+
+        return toast
+      })
+    } else {
+      this.addToast({ component, dismissible, id, ...data })
+    }
     return id
   }
 


### PR DESCRIPTION
# Description
Currently, toast.dismiss() only works with toasts created using toast() or similar built-in APIs, but not with toast.custom().

# Solution
This implementation registers custom toasts in the internal toast queue, allowing them to be dismissed using toast.dismiss().

# References

> If you create your custom toast, `toast.dismiss` will not work (i forgot the reason tho). I think the `toast.dismiss` only close the original toast, not our custom toast. 
> 
> 
> 
> Vue sonner do not provide clear api to close the toast. After going deeper into the code, it turns out that to close the toast, we need to create emitter named `closeToast` and then emit it. Just try it out, and see if that works  

 _Originally posted by @thoriqadillah in [#50](https://github.com/xiaoluoboding/vue-sonner/issues/50#issuecomment-2038122433)_