### PR TITLE
feat: add isPaused prop to headlessToast for custom progressBars

### DIFF
--- a/app/components/HeadlessToast.vue
+++ b/app/components/HeadlessToast.vue
@@ -1,13 +1,14 @@
 <script setup lang="ts">
 import { toast } from '@/packages'
 
-defineProps<{ msg?: string }>()
+defineProps<{ msg?: string; isPaused?: boolean }>()
 </script>
 
 <template>
   <div class="headless">
     <p class="headlessTitle">Event Created {{ msg }}</p>
     <p class="headlessDescription">Today at 4:00pm - "Louvre Museum"</p>
+    <p class="headlessDescription">is Paused : {{isPaused}}</p>
     <button class="headlessCloseAll" @click="toast.dismiss()">
       Close all
     </button>

--- a/src/packages/Toast.vue
+++ b/src/packages/Toast.vue
@@ -71,6 +71,7 @@
         :is="toast.component"
         v-bind="toast.componentProps"
         :onCloseToast="handleCloseToast"
+        :isPaused="$props.expanded || $props.interacting || isDocumentHidden"
       />
     </template>
 


### PR DESCRIPTION
This critical feature adds an isPaused prop to the headlessToast component in vue-sonner, allowing developers to control custom progress bars in toast notifications. By passing a reactive boolean value, users can pause or resume animations/timers based on interactions like hovering, addressing the library's lack of exposed hover events.
Usage is straightforward: bind isPaused to a state variable in your custom toast props, then apply it to CSS animations (e.g., animation-play-state: paused;) or JS logic for dynamic control.