### PR TITLE
feat: export ToastTypes

### DIFF
--- a/src/packages/index.ts
+++ b/src/packages/index.ts
@@ -6,7 +6,8 @@ import type {
   Action,
   ToastClasses,
   ToastToDismiss,
-  PromiseIExtendedResult
+  PromiseIExtendedResult,
+  ToastTypes
 } from './types'
 import { Toaster } from './component'
 import { toast } from './state'
@@ -22,7 +23,8 @@ export {
   type Action,
   type ToastClasses,
   type ToastToDismiss,
-  type PromiseIExtendedResult
+  type PromiseIExtendedResult,
+  type ToastTypes
 }
 
 const plugin: Plugin = {


### PR DESCRIPTION
For an application I'm working with I want to do some logic on ToasTypes, but for some reason this definition wasn't exposed. Right now I've copied ToastTypes in my application, but that obviously isn't maintainable. Hence this PR.